### PR TITLE
K3s remove requirement for sudo during usage

### DIFF
--- a/deployment/k8.gazebo-iris.amd64.yaml
+++ b/deployment/k8.gazebo-iris.amd64.yaml
@@ -97,7 +97,7 @@ spec:
           beta.kubernetes.io/arch: "amd64"
       containers:
       - name: gazebo
-        image: starling-sim-iris:latest
+        image: uobflightlabstarling/starling-sim-iris:latest
         resources:
           requests:
             cpu: "100m"

--- a/deployment/k8.px4-sitl.amd64.yaml
+++ b/deployment/k8.px4-sitl.amd64.yaml
@@ -38,7 +38,7 @@ spec:
       shareProcessNamespace: true
       initContainers:
       - name: gazebo-spawn-iris
-        image: starling-sim-iris:latest
+        image: uobflightlabstarling/starling-sim-iris:latest
         imagePullPolicy: IfNotPresent
         args: [ "./spawn_iris.sh" ]
         env:
@@ -50,7 +50,7 @@ spec:
           value: "true"
       containers:
       - name: starling-px4-sitl
-        image: starling-sim-px4-sitl:latest
+        image: uobflightlabstarling/starling-sim-px4-sitl:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: PX4_SIM_HOST
@@ -60,7 +60,7 @@ spec:
         - name: PX4_INSTANCE_BASE
           value: "200"
       - name: starling-mavros
-        image: starling-mavros:latest
+        image: uobflightlabstarling/starling-mavros:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: VEHICLE_NAMESPACE # Optional but unique

--- a/docs/details/kubernetes.md
+++ b/docs/details/kubernetes.md
@@ -5,8 +5,65 @@
 ## Overview
 
 
-## Kubernets in Starling
+## Kubernetes in Starling
 
+
+## Practical Details
+
+### Root/Non-root access
+
+By default the k3s installation creates a configuration file `k3s.yaml` which stores access tokens, the IP address of the master servers and various other information. By default this is stored in `/etc/rancher/k3s/k3s.yaml`. Any time `k3s` is invoked, i.e. any time you call `k3s kubectl ...`, this configuration file is accessed and read. However because the configuration file is stored in the system directory `/etc/`, by default any call to `k3s` would need `sudo`, i.e. `sudo k3s kubectl ...`. 
+
+This can be avoided by moving the `k3s.yaml` file to your local user directory. The recommended location is `~/.kube/config/k3s.yaml`, but it can be put anyway. The only requirement is that the `KUBECONFIG` environment variable should be set to the location of the configuration file. This can be achieved by adding the following line somewhere into your `~/.bashrc` (or `~/.zshrc` if using zsh):
+
+```bash
+export KUBECONFIG=~/.kube/config/k3s.yaml
+```
+> **Note:** Do not forget to source your bashrc after making the change to see the change in your terminal `source ~/.bashrc`
+
+Once this is set, any call of `k3s ...` will not require `sudo`. 
+
+### Access Across Machines
+
+If you are in the BRL Flight Arena, or you are running a multiple machine cluster, you may want to be able to run and test containers on a different physical machine to the machine running the cluster master node. As detailed in the above section on [non-root access](#rootnot-rootaccess), k3s generates the `k3s.yaml` configruation file. Importantly this file tells k3s what the ip of the master node is as shown in this example snippet of a k3s file:
+
+```yaml
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: <long data string>
+    server: https://127.0.0.1:6443 ### <---- This line! 
+  name: default
+contexts:
+- context:
+    cluster: default
+    user: default
+  name: default
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: default
+  user:
+    client-certificate-data: <another long data string>
+    client-key-data: < secret client key!>
+```
+
+To therefore access the master node (and the dashboard and kubectl etc) on another machine, you must.
+
+1. Copy the `k3s.yaml` file off of the server onto your own machine. 
+2. In the `k3s.yaml` change the server ip from `127.0.0.1` to the ip address of the master machine. 
+3. Ensure that either KUBECONFIG is set, or you have replaced the filee at `~/.kube/config/k3s.yaml` with your own modified one (may need sudo)
+
+Once that is set up verify that you can get the dashboard access token and log in.
+
+```bash
+k3s kubectl -n kubernetes-dashboard describe secret admin-user-token | grep ^token
+```
+
+Also then verify that you can run any of the kubernetes deployments, and that they will be deployed to the master cluster (and not your own).
+
+> **Note:** Even if the cluster is not running on your local machine, you will still need to install the k3s binaries. The command run by `run_k3s.sh` or `./scripts/start_k3s.sh` both download and then automatically start k3s in the background of your machine. To stop it from starting, pass the `--do-not-start` option to either command. If you have already have k3s running, run `k3s-killall.sh` which will stop all k3s processes without uninstalling it entirely (so you still get access to the k3s command line tools). 
 
 ## Configuration Files
 

--- a/docs/details/kubernetes.md
+++ b/docs/details/kubernetes.md
@@ -51,7 +51,7 @@ users:
 
 To therefore access the master node (and the dashboard and kubectl etc) on another machine, you must.
 
-1. Copy the `k3s.yaml` file off of the server onto your own machine. 
+1. Copy the `k3s.yaml` file off of the server onto your own machine. (For the BRL, see below)
 2. In the `k3s.yaml` change the server ip from `127.0.0.1` to the ip address of the master machine. 
 3. Ensure that either KUBECONFIG is set, or you have replaced the filee at `~/.kube/config/k3s.yaml` with your own modified one (may need sudo)
 
@@ -64,6 +64,8 @@ k3s kubectl -n kubernetes-dashboard describe secret admin-user-token | grep ^tok
 Also then verify that you can run any of the kubernetes deployments, and that they will be deployed to the master cluster (and not your own).
 
 > **Note:** Even if the cluster is not running on your local machine, you will still need to install the k3s binaries. The command run by `run_k3s.sh` or `./scripts/start_k3s.sh` both download and then automatically start k3s in the background of your machine. To stop it from starting, pass the `--do-not-start` option to either command. If you have already have k3s running, run `k3s-killall.sh` which will stop all k3s processes without uninstalling it entirely (so you still get access to the k3s command line tools). 
+
+In the BRL, to get the k3s.yaml file, you should simply be able to scp (ssh copy) the file from the master machine `~/.kube/config/k3s.yaml` to your local machine, and change the IP address.
 
 ## Configuration Files
 

--- a/docs/guide/kube-single-drone-local-machine.md
+++ b/docs/guide/kube-single-drone-local-machine.md
@@ -37,6 +37,8 @@ This will start the following:
 
 > **Note:** this might take a while on first run as downloads are required.
 
+> **Note:** this installation will ask for root (sudo) permission when necessary.
+
 The User Interfaces are available in the following locations:
 
 - Go to [`http://localhost:8080`](http://localhost:8080) in a browser to (hopefully) see the gazebo simulator.
@@ -56,6 +58,7 @@ There may be cases where you wish to restart or refresh either the software runn
 ./run_k3s.sh -d # or --delete will remove the gazebo and drone instances
 ./run_k3s.sh -r # or --restart will restart the gazebo and drone instances
 ```
+> **Note:** you can also add the `-sk` command which will skip the k3s re-download step and the dashboard check, i.e. `./run_k3s.sh -sk -r`
 
 If you wish to remove the cluster and all associated software from the machine, you will need to uninstall:
 ```bash
@@ -106,63 +109,9 @@ To remove or restart the controller, use the `-d` or `-r` options respectively w
 ./scripts/start_example_controller.sh -d # Delete or Remove controller
 ./scripts/start_example_controller.sh -r # Restart controller
 ```
-
 ### Onboard Control
 {% include 'snippets/onboard-control.md' %}
 
-
-## Development on the Drone and Simulator 
-
-### Useful Scripts:
-
-There are a number of useful scripts in the `/scripts` directory of this repository. Scripts can be run from any location, but for this tutorial we assume the user is in the root directory.
-
-1. `./scripts/start_k3s.sh` - This starts the cluster 
-    -  `-u` will uninstall the cluster from the machine (and remove any running processes)
-2. `./scripts/start_single_px4sitl_gazebo.sh` - This starts the starling core functions (Dashboard and UI). It also starts the gazebo simulator and a 'drone' process running the PX4 SITL and a connected Mavros ROS2 node. Assumes the cluster has been started.
-    - `-d` will stop the gazebo and all connected 'drone' processes only (use if reloading the controller).
-    - `-r` will restart the gazebo and all connected 'drone' processes. 
-    - `-sk` will skip the starting/check that the starling core functions are running.
-    - `-ow` will automatically open the UI webpages.
-3. `./scripts/start_starling_base.sh` - This starts the starling user interface and dashboard. Automatically run by `start_single_px4sitl_gazebo.sh` 
-4. `./scripts/start_dashboard.sh` - This starts the dashboard process on the cluster. Assumes the cluster has already been started. Automatically run by `start_single_px4sitl_gazebo.sh` and `start_starling_base.sh` 
-    - `-ow` will automatically open the UI webpages.
-
-> **Note:** The `./run_k3s` script internally runs `start_k3s.sh` and `start_single_px4sitl_gazebo.sh`. Any options passed will be forwarded to the relevant script.
-### Modifying the example controller
-In the [controllers](https://github.com/UoBFlightLab/ProjectStarling/tree/master/controllers) folder there is an example_controller_python which you should have seen in action in the example above. The ROS2 package is in [example_controller_python](https://github.com/UoBFlightLab/ProjectStarling/tree/master/controllers/example_controller_python/example_controller_python). Any edits made to the ROS2 package can be built by running `make` in the controllers directory. This will use colcon build to build the node and output a local image named `example_controller_python`. 
-
-Inside the controllers folder, there is an annotated kubernetes config file [`k8.example_controller_python.amd64.yaml`](https://github.com/UoBFlightLab/ProjectStarling/blob/master/controllers/example_controller_python/k8.example_controller_python.amd64.yaml). This specifies the deployment of a *pod* which contains your local `example_controller_python` image ([this line](https://github.com/UoBFlightLab/ProjectStarling/blob/227b22fbd97ac58f5b34e4154e58d01f72f29988/controllers/example_controller_python/k8.example_controller_python.amd64.yaml#L49)). 
-
-Similar to before you can start up the local example controller by using the script:
-```bash
-./scripts/start_example_controller.sh
-```
-But if you have made a copy, or wish to run your own version of the configuration, you can manually deploy your controller by running the following:
-```bash
-sudo k3s apply -f k8.example_controller_python.amd64.yaml
-sudo k3s delete -f k8.example_controller_python.amd64.yaml # To delete
-```
-See [kuberenets configuration](../details/kubernetes.md) for more details.  
-
-For debugging, you can both see the logs, and execute on your controller container through the dashboard. See [instructions here](../details/kubernetes-dashboard.md)
-
-Inside you can `source install/setup.bash` and run ROS2 commands like normal. 
-
-### Creating your own from scratch
-
-Of course you can create your own controller from scratch. Inside your controller repository, the following is required
-1. Your ROS2 package folder (what would usually go inside the `dev_ws/src` directory)
-2. A Dockerfile (named `Dockerfile`) which is dervied `FROM uobflightlabstarling/starling-controller-base`, use the [example Dockerfile](controllers/example_controller_python/Dockerfile) as a template. 
-3. A Kubernetes YAML config file specifying either a Pod or a deployment. Use the example `k8.example_controller_python.amd64.yaml` as a template. There are annoated comments. Also see [here](../details/kubernetes.md) for more details.  
-
-Your Dockerfile can be built by running the following in the directory with the Dockerfile.
-```
-docker build -t <name of your controller> .
-```
-Once built, the configuration file must have a container config specifying your own image name. 
-
-Your container can then be deployed manually using `k3s apply -f <your config>.yaml` as above.
-
+{% include 'snippets/drone-dev.md' %}
 
 ## Troubleshooting/ FAQs

--- a/docs/guide/multiple-drone-local-machine.md
+++ b/docs/guide/multiple-drone-local-machine.md
@@ -38,6 +38,8 @@ This will start the following:
 
 > **Note:** this might take a while on first run as downloads are required.
 
+> **Note:** this installation will ask for root (sudo) permission when necessary.
+
 The User Interfaces are available in the following locations:
 
 - Go to [`http://localhost:8080`](http://localhost:8080) in a browser to (hopefully) see the gazebo simulator.
@@ -57,6 +59,8 @@ There may be cases where you wish to restart or refresh either the software runn
 ./run_k3s.sh -d # or --delete will remove the gazebo and drone instances
 ./run_k3s.sh -r # or --restart will restart the gazebo and drone instances
 ```
+
+> **Note:** you can also add the `-sk` command which will skip the k3s re-download step and the dashboard check, i.e. `./run_k3s.sh -sk -r`
 
 If you wish to remove the cluster and all associated software from the machine, you will need to uninstall:
 ```bash
@@ -146,59 +150,6 @@ To remove or restart the controller, use the `-d` or `-r` options respectively w
 ### Onboard Control
 {% include 'snippets/onboard-control.md' %}
 
-## Development on the Drone and Simulator 
-
-### Useful Scripts:
-
-There are a number of useful scripts in the `/scripts` directory of this repository. Scripts can be run from any location, but for this tutorial we assume the user is in the root directory.
-
-1. `./scripts/start_k3s.sh` - This starts the cluster 
-    -  `-u` will uninstall the cluster from the machine (and remove any running processes)
-2. `./scripts/start_single_px4sitl_gazebo.sh` - This starts the starling core functions (Dashboard and UI). It also starts the gazebo simulator and a 'drone' process running the PX4 SITL and a connected Mavros ROS2 node. Assumes the cluster has been started.
-    - `-d` will stop the gazebo and all connected 'drone' processes only (use if reloading the controller).
-    - `-r` will restart the gazebo and all connected 'drone' processes. 
-  labels:
-    app: nginx
-    - `-sk` will skip the starting/check that the starling core functions are running.
-    - `-ow` will automatically open the UI webpages.
-3. `./scripts/start_starling_base.sh` - This starts the starling user interface and dashboard. Automatically run by `start_single_px4sitl_gazebo.sh` 
-4. `./scripts/start_dashboard.sh` - This starts the dashboard process on the cluster. Assumes the cluster has already been started. Automatically run by `start_single_px4sitl_gazebo.sh` and `start_starling_base.sh` 
-    - `-ow` will automatically open the UI webpages.
-
-> **Note:** The `./run_k3s` script internally runs `start_k3s.sh` and `start_single_px4sitl_gazebo.sh`. Any options passed will be forwarded to the relevant script.
-### Modifying the example controller
-In the [controllers](https://github.com/UoBFlightLab/ProjectStarling/tree/master/controllers) folder there is an example_controller_python which you should have seen in action in the example above. The ROS2 package is in [example_controller_python](https://github.com/UoBFlightLab/ProjectStarling/tree/master/controllers/example_controller_python/example_controller_python). Any edits made to the ROS2 package can be built by running `make` in the controllers directory. This will use colcon build to build the node and output a local image named `example_controller_python`. 
-
-Inside the controllers folder, there is an annotated kubernetes config file [`k8.example_controller_python.amd64.yaml`](https://github.com/UoBFlightLab/ProjectStarling/blob/master/controllers/example_controller_python/k8.example_controller_python.amd64.yaml). This specifies the deployment of a *pod* which contains your local `example_controller_python` image ([this line](https://github.com/UoBFlightLab/ProjectStarling/blob/227b22fbd97ac58f5b34e4154e58d01f72f29988/controllers/example_controller_python/k8.example_controller_python.amd64.yaml#L49)). 
-
-Similar to before you can start up the local example controller by using the script:
-```bash
-./scripts/start_example_controller.sh
-```
-But if you have made a copy, or wish to run your own version of the configuration, you can manually deploy your controller by running the following:
-```bash
-sudo k3s apply -f k8.example_controller_python.amd64.yaml
-sudo k3s delete -f k8.example_controller_python.amd64.yaml # To delete
-```
-See [kuberenets configuration](../details/kubernetes.md) for more details.  
-
-For debugging, you can both see the logs, and execute on your controller container through the dashboard. See [instructions here](../details/kubernetes-dashboard.md)
-
-Inside you can `source install/setup.bash` and run ROS2 commands like normal. 
-
-### Creating your own from scratch
-
-Of course you can create your own controller from scratch. Inside your controller repository, the following is required
-1. Your ROS2 package folder (what would usually go inside the `dev_ws/src` directory)
-2. A Dockerfile (named `Dockerfile`) which is dervied `FROM uobflightlabstarling/starling-controller-base`, use the [example Dockerfile](controllers/example_controller_python/Dockerfile) as a template. 
-3. A Kubernetes YAML config file specifying either a Pod or a deployment. Use the example `k8.example_controller_python.amd64.yaml` as a template. There are annoated comments. Also see [here](../details/kubernetes.md) for more details.  
-
-Your Dockerfile can be built by running the following in the directory with the Dockerfile.
-```
-docker build -t <name of your controller> .
-```
-Once built, the configuration file must have a container config specifying your own image name. 
-
-Your container can then be deployed manually using `k3s apply -f <your config>.yaml` as above.
+{% include 'snippets/drone-dev.md' %}
 
 ## Troubleshooting/ FAQs

--- a/docs/snippets/drone-dev.md
+++ b/docs/snippets/drone-dev.md
@@ -1,0 +1,55 @@
+## Development on the Drone and Simulator 
+
+### Useful Scripts:
+
+There are a number of useful scripts in the `/scripts` directory of this repository. Scripts can be run from any location, but for this tutorial we assume the user is in the root directory.
+
+1. `./scripts/start_k3s.sh` - This starts the cluster 
+    -  `-u` will uninstall the cluster from the machine (and remove any running processes)
+    - `-sk` will skip the installation check for k3s
+2. `./scripts/start_single_px4sitl_gazebo.sh` - This starts the starling core functions (Dashboard and UI). It also starts the gazebo simulator and a 'drone' process running the PX4 SITL and a connected Mavros ROS2 node. Assumes the cluster has been started.
+    - `-d` will stop the gazebo and all connected 'drone' processes only (use if reloading the controller).
+    - `-r` will restart the gazebo and all connected 'drone' processes. 
+  labels:
+    app: nginx
+    - `-sk` will skip the starting/check that the starling core functions are running.
+    - `-ow` will automatically open the UI webpages.
+3. `./scripts/start_starling_base.sh` - This starts the starling user interface and dashboard. Automatically run by `start_single_px4sitl_gazebo.sh` 
+4. `./scripts/start_dashboard.sh` - This starts the dashboard process on the cluster. Assumes the cluster has already been started. Automatically run by `start_single_px4sitl_gazebo.sh` and `start_starling_base.sh` 
+    - `-ow` will automatically open the UI webpages.
+
+> **Note:** The `./run_k3s` script internally runs `start_k3s.sh` and `start_single_px4sitl_gazebo.sh`. Any options passed will be forwarded to the relevant script.
+### Modifying the example controller
+In the [controllers](https://github.com/UoBFlightLab/ProjectStarling/tree/master/controllers) folder there is an example_controller_python which you should have seen in action in the example above. The ROS2 package is in [example_controller_python](https://github.com/UoBFlightLab/ProjectStarling/tree/master/controllers/example_controller_python/example_controller_python). Any edits made to the ROS2 package can be built by running `make` in the controllers directory. This will use colcon build to build the node and output a local image named `example_controller_python`. 
+
+Inside the controllers folder, there is an annotated kubernetes config file [`k8.example_controller_python.amd64.yaml`](https://github.com/UoBFlightLab/ProjectStarling/blob/master/controllers/example_controller_python/k8.example_controller_python.amd64.yaml). This specifies the deployment of a *pod* which contains your local `example_controller_python` image ([this line](https://github.com/UoBFlightLab/ProjectStarling/blob/227b22fbd97ac58f5b34e4154e58d01f72f29988/controllers/example_controller_python/k8.example_controller_python.amd64.yaml#L49)). 
+
+Similar to before you can start up the local example controller by using the script:
+```bash
+./scripts/start_example_controller.sh
+```
+But if you have made a copy, or wish to run your own version of the configuration, you can manually deploy your controller by running the following:
+```bash
+k3s apply -f k8.example_controller_python.amd64.yaml
+k3s delete -f k8.example_controller_python.amd64.yaml # To delete
+```
+See [kuberenets configuration](../details/kubernetes.md) for more details.  
+
+For debugging, you can both see the logs, and execute on your controller container through the dashboard. See [instructions here](../details/kubernetes-dashboard.md)
+
+Inside you can `source install/setup.bash` and run ROS2 commands like normal. 
+
+### Creating your own from scratch
+
+Of course you can create your own controller from scratch. Inside your controller repository, the following is required
+1. Your ROS2 package folder (what would usually go inside the `dev_ws/src` directory)
+2. A Dockerfile (named `Dockerfile`) which is dervied `FROM uobflightlabstarling/starling-controller-base`, use the [example Dockerfile](controllers/example_controller_python/Dockerfile) as a template. 
+3. A Kubernetes YAML config file specifying either a Pod or a deployment. Use the example `k8.example_controller_python.amd64.yaml` as a template. There are annoated comments. Also see [here](../details/kubernetes.md) for more details.  
+
+Your Dockerfile can be built by running the following in the directory with the Dockerfile.
+```
+docker build -t <name of your controller> .
+```
+Once built, the configuration file must have a container config specifying your own image name. 
+
+Your container can then be deployed manually using `k3s apply -f <your config>.yaml` as above.

--- a/run_k3s.sh
+++ b/run_k3s.sh
@@ -11,6 +11,10 @@ do
             HELP=1
             shift # past argument
             ;;
+        -sk|--skip-install)
+            SKIP=1
+            shift
+            ;;
         *)    # unknown option
             POSITIONAL+=("$1") # save it in an array for later
             shift # past argument
@@ -26,14 +30,17 @@ then
     echo "Usage: './run_k3s.sh [-h|--help] [-d|--delete]"
     echo "-h|--help: prints this dialogue"
     echo "-d|--delete: removes everything k3s on the system (k3s-uninstall)"
+    echo "-sk|--skip-install: skips the installation (and requirement for sudo"
     exit -1
 fi
 
 SCRIPTSDIR=scripts
 
-# Start K3S 
-# Only accepts -u|--uninstall 
-./$SCRIPTSDIR/start_k3s.sh $ARGS
+if [[ ! $SKIP ]]; then
+    # Start K3S 
+    # Only accepts -u|--uninstall 
+    ./$SCRIPTSDIR/start_k3s.sh $ARGS
+fi
 
 # Start Gazebo and Single PX4 drone
 # Accepts the following [-ow|--open], [-d|--delete], [-sk|--skip-base-check], [-r|--restart]

--- a/scripts/get_dashboard_token.sh
+++ b/scripts/get_dashboard_token.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo k3s kubectl -n kubernetes-dashboard describe secret admin-user-token | grep ^token | cut -c 13-
+k3s kubectl -n kubernetes-dashboard describe secret admin-user-token | grep ^token | cut -c 13-

--- a/scripts/start_dashboard.sh
+++ b/scripts/start_dashboard.sh
@@ -29,21 +29,23 @@ then
 fi
 
 echo "Deploying Kubernetes Dashboard"
-echo "See: https://blog.tekspace.io/deploying-kubernetes-dashboard-in-k3s-cluster/ for more details"
+echo "See: https://rancher.com/docs/k3s/latest/en/installation/kube-dashboard/ for more details"
 echo "==================="
 GITHUB_URL=https://github.com/kubernetes/dashboard/releases
 VERSION_KUBE_DASHBOARD=$(curl -w '%{url_effective}' -I -L -s -S ${GITHUB_URL}/latest -o /dev/null | sed -e 's|.*/||')
-sudo k3s kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/${VERSION_KUBE_DASHBOARD}/aio/deploy/recommended.yaml
-sudo k3s kubectl apply -f ${SCRIPT_DIR}/../deployment/resources/dashboard.admin.yaml #dashboard.admin-user.yml -f deployment/resources/dashboard.admin-user-role.yml
+k3s kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/${VERSION_KUBE_DASHBOARD}/aio/deploy/recommended.yaml
+k3s kubectl apply -f ${SCRIPT_DIR}/../deployment/resources/dashboard.admin.yaml #dashboard.admin-user.yml -f deployment/resources/dashboard.admin-user-role.yml
 echo "==================="
 
-DASHBOARD_TOKEN=`sudo k3s kubectl -n kubernetes-dashboard describe secret admin-user-token | grep ^token | cut -c 13-`
+DASHBOARD_TOKEN=`k3s kubectl -n kubernetes-dashboard describe secret admin-user-token | grep ^token | cut -c 13-`
 
 echo "The Dashboard is available at https://localhost:31771"
 echo "You will need the dashboard token, to access it."
 if command -v xclip; then
+    set +e # Will fail if there is no xserver running, e.g. via ssh. Fail silently
     echo $DASHBOARD_TOKEN | xclip -selection clipboard -i
     echo "The token has been copied onto your clipboard, it is also printed below"
+    set -e
 else
     echo "Copy and paste the token from below"
 fi
@@ -51,5 +53,5 @@ echo "-----BEGIN DASHBOARD TOKEN-----"
 echo $DASHBOARD_TOKEN
 echo "-----END DASHBOARD TOKEN-----"
 echo "Note: your browser may not like the self signed ssl certificate, ignore and continue for now"
-echo "To get the token yourself run: sudo k3s kubectl -n kubernetes-dashboard describe secret admin-user-token"
+echo "To get the token yourself run: k3s kubectl -n kubernetes-dashboard describe secret admin-user-token"
 echo "==================="

--- a/scripts/start_example_controller.sh
+++ b/scripts/start_example_controller.sh
@@ -41,7 +41,7 @@ SCRIPTSDIR="${BASH_SOURCE%/*}"
 CONTROLLERSDIR="$SCRIPTSDIR/../controllers"
 
 if [[ $DELETE ]]; then
-    sudo k3s delete -f $CONTROLLERSDIR/example_controller_python/k8.example_controller_python.amd64.yaml
+    k3s delete -f $CONTROLLERSDIR/example_controller_python/k8.example_controller_python.amd64.yaml
 fi
 
 if [[ $RESTART ]]; then
@@ -51,5 +51,5 @@ fi
 
 if [[ ! $DELETE || $RESTART ]]; then
     make controllers 
-    sudo k3s apply -f $CONTROLLERSDIR/example_controller_python/k8.example_controller_python.amd64.yaml
+    k3s apply -f $CONTROLLERSDIR/example_controller_python/k8.example_controller_python.amd64.yaml
 fi

--- a/scripts/start_k3s.sh
+++ b/scripts/start_k3s.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -e
 
+KUBECONFIGDIR=~/.kube
+CONFIGFILE=$KUBECONFIGDIR/config/k3s.yaml
+
+declare -a RCFILES=(
+    ~/.zshrc
+    ~/.bashrc
+)
 
 # Parse arguments
 POSITIONAL=()
@@ -16,6 +23,11 @@ do
             UNINSTALL=1
             shift
             ;;
+        --config-file)
+            CONFIGFILE=$2 
+            shift
+            shift
+            ;;
         *)    # unknown option
             POSITIONAL+=("$1") # save it in an array for later
             shift # past argument
@@ -28,19 +40,58 @@ if [[ $HELP ]]
 then
     echo "Script downloads and runs k3s on the system"
     echo "Default runs the system with the --docker parameter"
+    echo "k3s config file can be set with --config-file <filepath>, defaults to $CONFIGFILE"
     exit -1
 fi
 
 if [[ ! $UNINSTALL ]]; then
+
     # Only needs to be run once per system
     # Download and start kubernetes master node 
     echo "Downloading and Running K3s in systemd (Will not do anything if k3s already installed and running"
-    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--docker" sh -
+    echo "The configuration file will be placed in $CONFIGFILE"
+    echo "root is required for initial installation (running of the kubernetes systemd)"
+    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--docker" sudo sh -
 
+    # Making local directory for storing config file
+    echo "Created directory $(dirname "${CONFIGFILE}") for storing config file"
+    mkdir -p "$(dirname "${CONFIGFILE}")"
+    sudo cp /etc/rancher/k3s/k3s.yaml $CONFIGFILE
+    sudo chmod 644 $CONFIGFILE
+    sudo chown $USER:$USER $CONFIGFILE
+    echo "Copied /etc/rancher/k3s/k3s.yaml -> $CONFIGFILE"
+
+    echo "Setting KUBECONFIG in rcfiles"
+    for rcfile in "${RCFILES[@]}"; do
+        if [[ -f $rcfile ]]; then
+            case `grep -F KUBECONFIG $rcfile >/dev/null; echo $?` in
+                0)
+                    echo "KUBECONFIG already set in $rcfile, KUBECONFIG NOT added to $rcfile"
+                    ;;
+                1)
+                    echo "export KUBECONFIG=$CONFIGFILE" >> $rcfile
+                    echo "$rcfile appended KUBECONFIG, set to $CONFIGFILE"
+                    ;;
+                *)
+                    echo "Error occured in setting KUBECONFIG in $rcfile"
+                    RED='\033[0;31m'
+                    NC='\033[0m'
+                    echo "${RED}Please manually ensure that KUBECONFIG is set to $CONFIGFILE in .profile or .bashrc file${NC}"
+                    ;;
+            esac
+        else
+            echo "$rcfile not found"
+        fi
+    done
+    
     echo "All actions completed"
     echo "k3s will run in the background systemd permanently"
     echo "run this script with the --uninstall flag or 'k3s-uninstall.sh' to remove all of k3s"
 else
     echo "Removing k3s"
-    k3s-uninstall.sh
+    sudo k3s-uninstall.sh
+    echo "Removed k3s from system"
+    rm -r $KUBECONFIGDIR
+    echo "Removed k3s config from $KUBECONFIGDIR"
+    exit 1
 fi

--- a/scripts/start_single_px4sitl_gazebo.sh
+++ b/scripts/start_single_px4sitl_gazebo.sh
@@ -57,9 +57,9 @@ DEPLOYMENTDIR="$SCRIPTSDIR/../deployment"
 
 if [[ $DELETE ]]; then
     echo "Deleting Gazebo-iris"
-    sudo k3s kubectl delete -f $DEPLOYMENTDIR/k8.gazebo-iris.amd64.yaml
+    k3s kubectl delete -f $DEPLOYMENTDIR/k8.gazebo-iris.amd64.yaml
     echo "Deleting px4-sitl with mavros"
-    sudo k3s kubectl delete -f $DEPLOYMENTDIR/k8.px4-sitl.amd64.yaml
+    k3s kubectl delete -f $DEPLOYMENTDIR/k8.px4-sitl.amd64.yaml
 fi
 
 if [[ $RESTART ]]; then
@@ -79,13 +79,13 @@ if [[ ! $DELETE || $RESTART ]]; then
 
     echo "Deploying Starling Modules (this may take a while)"
     echo "Deploying Gazebo-iris to localhost:8080 and wait for start"
-    sudo k3s kubectl apply -f $DEPLOYMENTDIR/k8.gazebo-iris.amd64.yaml
+    k3s kubectl apply -f $DEPLOYMENTDIR/k8.gazebo-iris.amd64.yaml
 
     echo "Waiting 5s for Gazebo to start to ensure proper connection"
     sleep 5s
 
     echo "Deploying px4-sitl with mavros"
-    sudo k3s kubectl apply -f $DEPLOYMENTDIR/k8.px4-sitl.amd64.yaml
+    k3s kubectl apply -f $DEPLOYMENTDIR/k8.px4-sitl.amd64.yaml
 
     if [[ $OPENWEBPAGE ]]
     then

--- a/scripts/start_starling_base.sh
+++ b/scripts/start_starling_base.sh
@@ -48,7 +48,7 @@ SYSTEMDIR="$SCRIPTSDIR/../system"
 ./$SCRIPTSDIR/start_dashboard.sh
 
 # Start starling UI
-sudo k3s kubectl apply -f "$SYSTEMDIR/ui/kubernetes.yaml"
+k3s kubectl apply -f "$SYSTEMDIR/ui/kubernetes.yaml"
 
 if [[ $OPENWEBPAGE ]]
 then


### PR DESCRIPTION
This PR updates the `./scripts/start_k3s.sh` script so that sudo is only required for initial install. 

By following [these instructions for cluster access](https://rancher.com/docs/k3s/latest/en/cluster-access/), the `k3s.yaml` configuration file is copied, chmod 644 and chowned to a user specified argument, defaulting to `~/.kube/config/k3s.yaml`. An attempt was made for the install script to automatically do the installation of k3s.yaml using the env variables described [here](https://rancher.com/docs/k3s/latest/en/installation/install-options/server-config/#client-options) but it was not successful. Therefore the script does this for you. 

The script then attempts to add `export KUBECONFIG=$CONFIGFILE` to the bottom of both bashrc and zshrc if they exist and the string KUBECONFIG does not already exist in the file. 

Docs have also been updated. 

Closes #38 
Closes #32 