### PR TITLE
Ros2 port of clover libraries

### DIFF
--- a/buildtools/docker-bake.hcl
+++ b/buildtools/docker-bake.hcl
@@ -34,7 +34,7 @@ group "stage1" {
 }
 
 group "stage2" {
-    targets = ["simulator-px4", "example_python_controller"]    
+    targets = ["simulator-px4", "starling-clover", "example_python_controller"]    
 }
 
 group "stage3" {
@@ -174,4 +174,20 @@ target "starling-sim-iris" {
     platforms = ["linux/amd64"]
     cache-to = [ notequal("",BAKE_CACHETO_NAME) ? "${BAKE_CACHETO_REGISTRY}uobflightlabstarling/starling-sim-iris:${BAKE_CACHETO_NAME}" : "" ]
     cache-from = [ notequal("",BAKE_CACHEFROM_NAME) ? "${BAKE_CACHEFROM_REGISTRY}uobflightlabstarling/starling-sim-iris:${BAKE_CACHEFROM_NAME}" : "" ]
+}
+
+// This target depends on starling-controller-base
+target "starling-clover" {
+    context = "system/drones/clover
+    args = { 
+        "VERSION": "${BAKE_VERSION}",
+        "REGISTRY": "${BAKE_REGISTRY}"
+        }
+    tags = [
+        "${BAKE_REGISTRY}uobflightlabstarling/starling-clover:${BAKE_VERSION}",
+        notequal("",BAKE_RELEASENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-clover:${BAKE_RELEASENAME}": "",
+        ]
+    platforms = ["linux/arm64"]
+    cache-to = [ notequal("",BAKE_CACHETO_NAME) ? "${BAKE_CACHETO_REGISTRY}uobflightlabstarling/starling-clover:${BAKE_CACHETO_NAME}" : "" ]
+    cache-from = [ notequal("",BAKE_CACHEFROM_NAME) ? "${BAKE_CACHEFROM_REGISTRY}uobflightlabstarling/starling-clover:${BAKE_CACHEFROM_NAME}" : "" ]
 }

--- a/system/Makefile
+++ b/system/Makefile
@@ -1,6 +1,6 @@
 MAKEFILE_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
-all: mavros controller-base
+all: mavros controller-base drones
 
 controller-base:
 	docker build -t starling-controller-base $(MAKEFILE_DIR)/controller-base
@@ -14,4 +14,7 @@ mavros_all_arch:
 ui:
 	docker build -t starling-ui $(MAKEFILE_DIR)/ui
 
-.PHONY: mavros mavros_all_arch controller-base ui all
+drones: controller-base mavros
+	$(MAKE) -C drones
+
+.PHONY: mavros mavros_all_arch controller-base ui all drones

--- a/system/drones/Makefile
+++ b/system/drones/Makefile
@@ -1,0 +1,12 @@
+MAKEFILE_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+all: clover
+
+clover-local:
+	docker build -t starling-clover ${MAKEFILE_DIR}/clover
+
+clover: 
+	docker buildx build --push --platform linux/arm64,linux/amd64 --tag mickeyli789/starling-clover:latest $(MAKEFILE_DIR)/clover 
+
+.PHONY: clover-local clover
+

--- a/system/drones/Makefile
+++ b/system/drones/Makefile
@@ -6,7 +6,7 @@ clover-local:
 	docker build -t starling-clover ${MAKEFILE_DIR}/clover
 
 clover: 
-	docker buildx build --push --platform linux/arm64,linux/amd64 --tag mickeyli789/starling-clover:latest $(MAKEFILE_DIR)/clover 
+	docker buildx build --push --build-arg START_HERE=$(date +%s) --platform linux/arm64,linux/amd64 --tag mickeyli789/starling-clover:latest $(MAKEFILE_DIR)/clover 
 
 .PHONY: clover-local clover
 

--- a/system/drones/Makefile
+++ b/system/drones/Makefile
@@ -6,7 +6,7 @@ clover-local:
 	docker build -t starling-clover ${MAKEFILE_DIR}/clover
 
 clover: 
-	docker buildx build --push --build-arg START_HERE=$(date +%s) --platform linux/arm64,linux/amd64 --tag mickeyli789/starling-clover:latest $(MAKEFILE_DIR)/clover 
+	docker buildx build --push --build-arg START_HERE=$(shell date +%s) --platform linux/arm64,linux/amd64 --tag uobflightlabstarling/starling-clover:latest $(MAKEFILE_DIR)/clover 
 
 .PHONY: clover-local clover
 

--- a/system/drones/clover/Dockerfile
+++ b/system/drones/clover/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
         python3-pip \
         geographiclib-tools\
         libgeographic-dev\
-        libgeographic19
+        libgeographic19\
     && rm -rf /var/lib/apt/lists/*
 
 ## Install Raspberry Pi GPIO drivers

--- a/system/drones/clover/Dockerfile
+++ b/system/drones/clover/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /ros_ws
 
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
     && . install/setup.sh \
-    && bash src/mavros/scripts/install_geographiclib_dataset.sh \
+    && bash src/mavros/mavros/scripts/install_geographiclib_dataset.sh \
     && ln -s /usr/share/cmake/geographiclib/FindGeographicLib.cmake /usr/share/cmake-3.16/Modules
 
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh \

--- a/system/drones/clover/Dockerfile
+++ b/system/drones/clover/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
 ## Install Raspberry Pi GPIO drivers
 RUN pip3 install RPi.GPIO
 
+ARG START_HERE=blah
 ## My own files for clover core libraries
 RUN git clone https://github.com/UoBFlightLab/clover_ros2_pkgs.git \
         /ros_ws/src/clover_ros2_pkgs

--- a/system/drones/clover/Dockerfile
+++ b/system/drones/clover/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /ros_ws
 
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
     && . install/setup.sh \
-    && ros2 run mavros install_geographiclib_dataset.sh \
+    && ./src/mavros/scripts/install_geographiclib_dataset.sh \
     && ln -s /usr/share/cmake/geographiclib/FindGeographicLib.cmake /usr/share/cmake-3.16/Modules
 
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh \

--- a/system/drones/clover/Dockerfile
+++ b/system/drones/clover/Dockerfile
@@ -14,7 +14,7 @@ RUN pip3 install RPi.GPIO
 
 ARG START_HERE=blah
 ## My own files for clover core libraries
-RUN git clone https://github.com/UoBFlightLab/clover_ros2_pkgs.git \
+RUN git clone --recursive https://github.com/UoBFlightLab/clover_ros2_pkgs.git \
         /ros_ws/src/clover_ros2_pkgs
 
 WORKDIR /ros_ws

--- a/system/drones/clover/Dockerfile
+++ b/system/drones/clover/Dockerfile
@@ -12,26 +12,6 @@ RUN apt-get update \
 ## Install Raspberry Pi GPIO drivers
 RUN pip3 install RPi.GPIO
 
-## Geographic Lib if neccessary
-# RUN git clone \
-#         --filter=blob:none --no-checkout\
-#         --single-branch --branch ros2 \
-#         https://github.com/ros-geographic-info/geographic_info.git \
-#         /ros_ws/src/geographic_info \
-#     && cd /ros_ws/src/geographic_info \
-#     && git checkout master --geographic_msgs
-
-## mavros_msgs should already be installed
-## Install ROS2 version just in case
-# RUN git clone \
-#         --no-checkout --depth 1\
-#         --single-branch --branch ros2 \
-#         https://github.com/mavlink/mavros.git \
-#         /ros_ws/src/mavros \
-#     && cd /ros_ws/src/mavros \
-#     && git sparse-checkout init --cone \
-#     && git sparse-checkout set mavros_msgs
-
 ## My own files for clover core libraries
 RUN git clone https://github.com/UoBFlightLab/clover_ros2_pkgs.git \
         /ros_ws/src/clover_ros2_pkgs
@@ -48,4 +28,7 @@ RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
         clover_ros2 \
     && rm -r build
 
-CMD [ "ros2", "launch", "clover_ros2", "clover.launch.xml"]
+COPY starling-clover.launch.xml .
+COPY run.sh .
+
+CMD ["./run.sh"]

--- a/system/drones/clover/Dockerfile
+++ b/system/drones/clover/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
         libboost-system-dev \
         git \
         python3-pip \
+        ros-foxy-mavros
     && rm -rf /var/lib/apt/lists/*
 
 ## Install Raspberry Pi GPIO drivers
@@ -19,6 +20,11 @@ RUN git clone --recursive https://github.com/UoBFlightLab/clover_ros2_pkgs.git \
 
 WORKDIR /ros_ws
 
+RUN rm -rf src/mavros \
+    && . /opt/ros/${ROS_DISTRO}/setup.sh \
+    && ros2 run mavros install_geographiclib_dataset.sh \
+    && ln -s /usr/share/cmake/geographiclib/FindGeographicLib.cmake /usr/share/cmake-3.16/Modules
+
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
     && export CMAKE_PREFIX_PATH=$AMENT_PREFIX_PATH:$CMAKE_PREFIX_PATH \
     && cd /ros_ws \
@@ -26,6 +32,7 @@ RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
         # mavros_msgs \
         led_msgs \
         ws281x \
+        vl53l1x \
         clover_ros2 \
     && rm -r build
 

--- a/system/drones/clover/Dockerfile
+++ b/system/drones/clover/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /ros_ws
 
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
     && . install/setup.sh \
-    && ./src/mavros/scripts/install_geographiclib_dataset.sh \
+    && bash src/mavros/scripts/install_geographiclib_dataset.sh \
     && ln -s /usr/share/cmake/geographiclib/FindGeographicLib.cmake /usr/share/cmake-3.16/Modules
 
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh \

--- a/system/drones/clover/Dockerfile
+++ b/system/drones/clover/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /ros_ws
 
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
     && . install/setup.sh \
-    && bash src/mavros/mavros/scripts/install_geographiclib_dataset.sh \
+    && bash src/mavros/mavros/scripts/install_geographiclib_datasets.sh \
     && ln -s /usr/share/cmake/geographiclib/FindGeographicLib.cmake /usr/share/cmake-3.16/Modules
 
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh \

--- a/system/drones/clover/Dockerfile
+++ b/system/drones/clover/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
         libboost-system-dev \
         git \
         python3-pip \
-        ros-foxy-mavros
+        ros-foxy-mavros \
     && rm -rf /var/lib/apt/lists/*
 
 ## Install Raspberry Pi GPIO drivers

--- a/system/drones/clover/Dockerfile
+++ b/system/drones/clover/Dockerfile
@@ -1,0 +1,51 @@
+ARG VERSION=latest
+ARG REGISTRY
+FROM ${REGISTRY}uobflightlabstarling/starling-controller-base:${VERSION}
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libboost-system-dev \
+        git \
+        python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+## Install Raspberry Pi GPIO drivers
+RUN pip3 install RPi.GPIO
+
+## Geographic Lib if neccessary
+# RUN git clone \
+#         --filter=blob:none --no-checkout\
+#         --single-branch --branch ros2 \
+#         https://github.com/ros-geographic-info/geographic_info.git \
+#         /ros_ws/src/geographic_info \
+#     && cd /ros_ws/src/geographic_info \
+#     && git checkout master --geographic_msgs
+
+## mavros_msgs should already be installed
+## Install ROS2 version just in case
+# RUN git clone \
+#         --no-checkout --depth 1\
+#         --single-branch --branch ros2 \
+#         https://github.com/mavlink/mavros.git \
+#         /ros_ws/src/mavros \
+#     && cd /ros_ws/src/mavros \
+#     && git sparse-checkout init --cone \
+#     && git sparse-checkout set mavros_msgs
+
+## My own files for clover core libraries
+RUN git clone https://github.com/UoBFlightLab/clover_ros2_pkgs.git \
+        /ros_ws/src/clover_ros2_pkgs
+
+WORKDIR /ros_ws
+
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
+    && export CMAKE_PREFIX_PATH=$AMENT_PREFIX_PATH:$CMAKE_PREFIX_PATH \
+    && cd /ros_ws \
+    && colcon build --packages-select \
+        # mavros_msgs \
+        led_msgs \
+        ws281x \
+        clover_ros2 \
+    && rm -r build
+
+CMD [ "ros2", "launch", "clover_ros2", "clover.launch.xml"]

--- a/system/drones/clover/Dockerfile
+++ b/system/drones/clover/Dockerfile
@@ -7,7 +7,9 @@ RUN apt-get update \
         libboost-system-dev \
         git \
         python3-pip \
-        ros-foxy-mavros \
+        geographiclib-tools\
+        libgeographic-dev\
+        libgeographic19
     && rm -rf /var/lib/apt/lists/*
 
 ## Install Raspberry Pi GPIO drivers
@@ -20,12 +22,13 @@ RUN git clone --recursive https://github.com/UoBFlightLab/clover_ros2_pkgs.git \
 
 WORKDIR /ros_ws
 
-RUN rm -rf src/mavros \
-    && . /opt/ros/${ROS_DISTRO}/setup.sh \
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
+    && . install/setup.sh \
     && ros2 run mavros install_geographiclib_dataset.sh \
     && ln -s /usr/share/cmake/geographiclib/FindGeographicLib.cmake /usr/share/cmake-3.16/Modules
 
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
+    && . install/setup.sh \
     && export CMAKE_PREFIX_PATH=$AMENT_PREFIX_PATH:$CMAKE_PREFIX_PATH \
     && cd /ros_ws \
     && colcon build --packages-select \

--- a/system/drones/clover/kubernetes.yaml
+++ b/system/drones/clover/kubernetes.yaml
@@ -30,7 +30,7 @@ spec:
       
       containers:
       - name: starling-clover
-        image: mickeyli789/starling-clover
+        image: uobflightlabstarling/starling-clover
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/system/drones/clover/kubernetes.yaml
+++ b/system/drones/clover/kubernetes.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: starling-clover
+spec:
+  hostNetwork: true
+  shareProcessNamespace: true
+  tolerations:
+  - key: "starling.dev/type"
+    operator: "Equal"
+    value: "vehicle"
+    effect: "NoSchedule"
+  containers:
+  - name: starling-clover
+    image: mickeyli789/starling-clover
+    imagePullPolicy: Always
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - mountPath: /dev/gpiomem
+      name: rpi-gpio
+    - mountPath: /etc/starling/vehicle.config
+      name: vehicleconfig
+      readOnly: true
+  nodeSelector:
+    k3s.io/hostname: clover12   
+  volumes:
+  - name: rpi-gpio
+    hostPath:
+      path: /dev/gpiomem
+  - name: vehicleconfig
+    hostPath:
+      path: /etc/starling/vehicle.config
+      type: File

--- a/system/drones/clover/kubernetes.yaml
+++ b/system/drones/clover/kubernetes.yaml
@@ -37,6 +37,8 @@ spec:
         volumeMounts:
         - mountPath: /dev/gpiomem
           name: rpi-gpio
+        - mountPath: /dev/i2c-1
+          name: i2c-1
         - mountPath: /etc/starling/vehicle.config
           name: vehicleconfig
           readOnly: true
@@ -45,6 +47,9 @@ spec:
       - name: rpi-gpio
         hostPath:
           path: /dev/gpiomem
+      - name: i2c-1
+        hostPath:
+          path: /dev/i2c-1
       - name: vehicleconfig
         hostPath:
           path: /etc/starling/vehicle.config

--- a/system/drones/clover/kubernetes.yaml
+++ b/system/drones/clover/kubernetes.yaml
@@ -1,35 +1,51 @@
----
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: DaemonSet
 metadata:
-  name: starling-clover
+  name: starling-clover-daemon
+  labels:
+    app: starling
+
 spec:
-  hostNetwork: true
-  shareProcessNamespace: true
-  tolerations:
-  - key: "starling.dev/type"
-    operator: "Equal"
-    value: "vehicle"
-    effect: "NoSchedule"
-  containers:
-  - name: starling-clover
-    image: mickeyli789/starling-clover
-    imagePullPolicy: Always
-    securityContext:
-      privileged: true
-    volumeMounts:
-    - mountPath: /dev/gpiomem
-      name: rpi-gpio
-    - mountPath: /etc/starling/vehicle.config
-      name: vehicleconfig
-      readOnly: true
-  nodeSelector:
-    k3s.io/hostname: clover12   
-  volumes:
-  - name: rpi-gpio
-    hostPath:
-      path: /dev/gpiomem
-  - name: vehicleconfig
-    hostPath:
-      path: /etc/starling/vehicle.config
-      type: File
+  selector: 
+    matchLabels:
+      name: starling-clover-daemon
+
+  template:
+    metadata:
+      labels:
+        name: starling-clover-daemon
+
+    spec:
+      nodeSelector:
+        starling.dev/vehicle-type: clover  
+      
+      tolerations:
+      - key: "starling.dev/type"
+        operator: "Equal"
+        value: "vehicle"
+        effect: "NoSchedule"
+
+      hostNetwork: true
+      shareProcessNamespace: true
+      
+      containers:
+      - name: starling-clover
+        image: mickeyli789/starling-clover
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /dev/gpiomem
+          name: rpi-gpio
+        - mountPath: /etc/starling/vehicle.config
+          name: vehicleconfig
+          readOnly: true
+      
+      volumes:
+      - name: rpi-gpio
+        hostPath:
+          path: /dev/gpiomem
+      - name: vehicleconfig
+        hostPath:
+          path: /etc/starling/vehicle.config
+          type: File

--- a/system/drones/clover/run.sh
+++ b/system/drones/clover/run.sh
@@ -1,0 +1,3 @@
+source /etc/starling/vehicle.config
+export VEHICLE_MAVLINK_SYSID
+ros2 launch starling-clover.launch.xml

--- a/system/drones/clover/starling-clover.launch.xml
+++ b/system/drones/clover/starling-clover.launch.xml
@@ -1,0 +1,12 @@
+<launch>
+    <arg name="vehicle_namespace" default="$(env VEHICLE_NAMESPACE vehicle_$(env VEHICLE_MAVLINK_SYSID))" />
+
+    <group>
+        <push-ros-namespace namespace="$(var vehicle_namespace)"/>
+        <!-- clover_ros2 -->
+        <include file="$(find-pkg-share clover_ros2)/launch/clover.launch.xml">
+            <!-- <arg name="simulator" value="$(var simulator)"/> -->
+        </include>
+    </group>
+
+</launch>


### PR DESCRIPTION
This PR adds the components required to use specific hardware on the clover drones.

Specifically it uses the ros2 clover port [here](https://github.com/UoBFlightLab/clover_ros2_pkgs). It is constructed as the `starling-clover` docker container

The proposal is that this container is run as a daemon over kubernetes, running on any node with the `type:clover` tag or similar.

Todo:

- [x] Add Kubernetes configuration
- [ ] Add port of clover camera