### PR TITLE
Build script updates

### DIFF
--- a/.github/workflows/update-dev-images.yml
+++ b/.github/workflows/update-dev-images.yml
@@ -47,7 +47,8 @@ jobs:
         env:
           BAKE_VERSION: ${{ steps.tag_name.outputs.GITHUB_TAG }}
           BAKE_RELEASENAME: nightly
-          BAKE_CACHENAME: cache-dev
+          BAKE_CACHETO_NAME: cache-dev
+          BAKE_CACHEFROM_NAME: cache-dev
 
       - name: Build and push (example_python_controller)
         uses: docker/bake-action@master
@@ -60,7 +61,8 @@ jobs:
         env:
           BAKE_VERSION: ${{ steps.tag_name.outputs.GITHUB_TAG }}
           BAKE_RELEASENAME: nightly
-          BAKE_CACHENAME: cache-dev
+          BAKE_CACHETO_NAME: cache-dev
+          BAKE_CACHEFROM_NAME: cache-dev
 
   #
   # Call bake for each simulator image in sequence
@@ -96,7 +98,8 @@ jobs:
         env:
           BAKE_VERSION: ${{ steps.tag_name.outputs.GITHUB_TAG }}
           BAKE_RELEASENAME: nightly
-          BAKE_CACHENAME: cache-dev
+          BAKE_CACHETO_NAME: cache-dev
+          BAKE_CACHEFROM_NAME: cache-dev
 
       - name: Build and push (sim-base-px4)
         uses: docker/bake-action@master
@@ -109,7 +112,8 @@ jobs:
         env:
           BAKE_VERSION: ${{ steps.tag_name.outputs.GITHUB_TAG }}
           BAKE_RELEASENAME: nightly
-          BAKE_CACHENAME: cache-dev
+          BAKE_CACHETO_NAME: cache-dev
+          BAKE_CACHEFROM_NAME: cache-dev
 
       - name: Build and push (sim-iris)
         uses: docker/bake-action@master
@@ -122,7 +126,8 @@ jobs:
         env:
           BAKE_VERSION: ${{ steps.tag_name.outputs.GITHUB_TAG }}
           BAKE_RELEASENAME: nightly
-          BAKE_CACHENAME: cache-dev
+          BAKE_CACHETO_NAME: cache-dev
+          BAKE_CACHEFROM_NAME: cache-dev
 
   #
   # Call bake for the SITL
@@ -158,7 +163,8 @@ jobs:
         env:
           BAKE_VERSION: ${{ steps.tag_name.outputs.GITHUB_TAG }}
           BAKE_RELEASENAME: nightly
-          BAKE_CACHENAME: cache-dev
+          BAKE_CACHETO_NAME: cache-dev
+          BAKE_CACHEFROM_NAME: cache-dev
 
   #
   # Call bake for the UI
@@ -199,7 +205,8 @@ jobs:
         env:
           BAKE_VERSION: ${{ steps.tag_name.outputs.GITHUB_TAG }}
           BAKE_RELEASENAME: nightly
-          BAKE_CACHENAME: cache-dev
+          BAKE_CACHETO_NAME: cache-dev
+          BAKE_CACHEFROM_NAME: cache-dev
 
   #
   # Call bake for mavros
@@ -240,4 +247,5 @@ jobs:
         env:
           BAKE_VERSION: ${{ steps.tag_name.outputs.GITHUB_TAG }}
           BAKE_RELEASENAME: nightly
-          BAKE_CACHENAME: cache-dev
+          BAKE_CACHETO_NAME: cache-dev
+          BAKE_CACHEFROM_NAME: cache-dev

--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -47,7 +47,8 @@ jobs:
         env:
           BAKE_VERSION: ${{ steps.tag_name.outputs.GITHUB_TAG }}
           BAKE_RELEASENAME: latest
-          BAKE_CACHENAME: cache
+          BAKE_CACHETO_NAME: cache
+          BAKE_CACHEFROM_NAME: cache
 
       - name: Build and push (example_python_controller)
         uses: docker/bake-action@master
@@ -60,7 +61,8 @@ jobs:
         env:
           BAKE_VERSION: ${{ steps.tag_name.outputs.GITHUB_TAG }}
           BAKE_RELEASENAME: latest
-          BAKE_CACHENAME: cache
+          BAKE_CACHETO_NAME: cache
+          BAKE_CACHEFROM_NAME: cache
 
   #
   # Call bake for each simulator image in sequence
@@ -96,7 +98,8 @@ jobs:
         env:
           BAKE_VERSION: ${{ steps.tag_name.outputs.GITHUB_TAG }}
           BAKE_RELEASENAME: latest
-          BAKE_CACHENAME: cache
+          BAKE_CACHETO_NAME: cache
+          BAKE_CACHEFROM_NAME: cache
 
       - name: Build and push (sim-base-px4)
         uses: docker/bake-action@master
@@ -109,7 +112,8 @@ jobs:
         env:
           BAKE_VERSION: ${{ steps.tag_name.outputs.GITHUB_TAG }}
           BAKE_RELEASENAME: latest
-          BAKE_CACHENAME: cache
+          BAKE_CACHETO_NAME: cache
+          BAKE_CACHEFROM_NAME: cache
 
       - name: Build and push (sim-iris)
         uses: docker/bake-action@master
@@ -122,7 +126,8 @@ jobs:
         env:
           BAKE_VERSION: ${{ steps.tag_name.outputs.GITHUB_TAG }}
           BAKE_RELEASENAME: latest
-          BAKE_CACHENAME: cache
+          BAKE_CACHETO_NAME: cache
+          BAKE_CACHEFROM_NAME: cache
 
   #
   # Call bake for the SITL
@@ -158,7 +163,8 @@ jobs:
         env:
           BAKE_VERSION: ${{ steps.tag_name.outputs.GITHUB_TAG }}
           BAKE_RELEASENAME: latest
-          BAKE_CACHENAME: cache
+          BAKE_CACHETO_NAME: cache
+          BAKE_CACHEFROM_NAME: cache
 
   #
   # Call bake for the UI
@@ -199,7 +205,8 @@ jobs:
         env:
           BAKE_VERSION: ${{ steps.tag_name.outputs.GITHUB_TAG }}
           BAKE_RELEASENAME: latest
-          BAKE_CACHENAME: cache
+          BAKE_CACHETO_NAME: cache
+          BAKE_CACHEFROM_NAME: cache
 
   #
   # Call bake for mavros
@@ -240,4 +247,5 @@ jobs:
         env:
           BAKE_VERSION: ${{ steps.tag_name.outputs.GITHUB_TAG }}
           BAKE_RELEASENAME: latest
-          BAKE_CACHENAME: cache
+          BAKE_CACHETO_NAME: cache
+          BAKE_CACHEFROM_NAME: cache

--- a/buildtools/docker-bake.hcl
+++ b/buildtools/docker-bake.hcl
@@ -10,8 +10,20 @@ variable "BAKE_RELEASENAME" {
     default = ""
 }
 
+variable "BAKE_CACHE_REGISTRY" {
+    default = "${BAKE_REGISTRY}"
+}
+
 variable "BAKE_CACHENAME" {
     default = ""
+}
+
+variable "BAKE_CACHENAME_FROM" {
+    default = "${BAKE_CACHENAME}"
+}
+
+variable "BAKE_CACHENAME_TO" {
+    default = "${BAKE_CACHENAME}"
 }
 
 /*
@@ -43,8 +55,8 @@ target "starling-ui" {
         notequal("",BAKE_RELEASENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-ui:${BAKE_RELEASENAME}": "",
         ]
     platforms = ["linux/amd64"]
-    cache-to = [ notequal("",BAKE_CACHENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-ui:${BAKE_CACHENAME}" : "" ]
-    cache-from = [ notequal("",BAKE_CACHENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-ui:${BAKE_CACHENAME}" : "" ]
+    cache-to = [ notequal("",BAKE_CACHENAME_TO) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-ui:${BAKE_CACHENAME_TO}" : "" ]
+    cache-from = [ notequal("",BAKE_CACHENAME_FROM) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-ui:${BAKE_CACHENAME_FROM}" : "" ]
 }
 
 target "starling-controller-base" {
@@ -54,8 +66,8 @@ target "starling-controller-base" {
         notequal("",BAKE_RELEASENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-controller-base:${BAKE_RELEASENAME}": "",
         ]
     platforms = ["linux/amd64", "linux/arm64"]
-    cache-to = [ notequal("",BAKE_CACHENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-controller-base:${BAKE_CACHENAME}" : "" ]
-    cache-from = [ notequal("",BAKE_CACHENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-controller-base:${BAKE_CACHENAME}" : "" ]
+    cache-to = [ notequal("",BAKE_CACHENAME_TO) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-controller-base:${BAKE_CACHENAME_TO}" : "" ]
+    cache-from = [ notequal("",BAKE_CACHENAME_FROM) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-controller-base:${BAKE_CACHENAME_FROM}" : "" ]
 }
 
 target "starling-mavros" {
@@ -65,8 +77,8 @@ target "starling-mavros" {
         notequal("",BAKE_RELEASENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-mavros:${BAKE_RELEASENAME}": "",
         ]
     platforms = ["linux/amd64", "linux/arm64"]
-    cache-to = [ notequal("",BAKE_CACHENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-mavros:${BAKE_CACHENAME}" : "" ]
-    cache-from = [ notequal("",BAKE_CACHENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-mavros:${BAKE_CACHENAME}" : "" ]
+    cache-to = [ notequal("",BAKE_CACHENAME_TO) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-mavros:${BAKE_CACHENAME_TO}" : "" ]
+    cache-from = [ notequal("",BAKE_CACHENAME_FROM) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-mavros:${BAKE_CACHENAME_FROM}" : "" ]
 }
 
 
@@ -87,8 +99,8 @@ target "starling-sim-base-core" {
         notequal("",BAKE_RELEASENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-sim-base-core:${BAKE_RELEASENAME}": "",
         ]
     platforms = ["linux/amd64"]
-    cache-to = [ notequal("",BAKE_CACHENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-sim-base-core:${BAKE_CACHENAME}" : "" ]
-    cache-from = [ notequal("",BAKE_CACHENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-sim-base-core:${BAKE_CACHENAME}" : "" ]
+    cache-to = [ notequal("",BAKE_CACHENAME_TO) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-sim-base-core:${BAKE_CACHENAME_TO}" : "" ]
+    cache-from = [ notequal("",BAKE_CACHENAME_FROM) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-sim-base-core:${BAKE_CACHENAME_FROM}" : "" ]
 }
 
 group "simulator-px4" {
@@ -110,8 +122,8 @@ target "starling-sim-base-px4" {
         notequal("",BAKE_RELEASENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-sim-base-px4:${BAKE_RELEASENAME}": "",
         ]
     platforms = ["linux/amd64"]
-    cache-to = [ notequal("",BAKE_CACHENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-sim-base-px4:${BAKE_CACHENAME}" : "" ]
-    cache-from = [ notequal("",BAKE_CACHENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-sim-base-px4:${BAKE_CACHENAME}" : "" ]
+    cache-to = [ notequal("",BAKE_CACHENAME_TO) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-sim-base-px4:${BAKE_CACHENAME_TO}" : "" ]
+    cache-from = [ notequal("",BAKE_CACHENAME_FROM) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-sim-base-px4:${BAKE_CACHENAME_FROM}" : "" ]
 }
 
 target "starling-sim-px4-sitl" {
@@ -122,8 +134,8 @@ target "starling-sim-px4-sitl" {
         notequal("",BAKE_RELEASENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-sim-px4-sitl:${BAKE_RELEASENAME}": "",
         ]
     platforms = ["linux/amd64"]
-    cache-to = [ notequal("",BAKE_CACHENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-sim-px4-sitl:${BAKE_CACHENAME}" : "" ]
-    cache-from = [ notequal("",BAKE_CACHENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-sim-px4-sitl:${BAKE_CACHENAME}" : "" ]
+    cache-to = [ notequal("",BAKE_CACHENAME_TO) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-sim-px4-sitl:${BAKE_CACHENAME_TO}" : "" ]
+    cache-from = [ notequal("",BAKE_CACHENAME_FROM) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-sim-px4-sitl:${BAKE_CACHENAME_FROM}" : "" ]
 }
 
 /*
@@ -141,8 +153,8 @@ target "example_python_controller" {
         notequal("",BAKE_RELEASENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/example_controller_python:${BAKE_RELEASENAME}": "",
         ]
     platforms = ["linux/amd64", "linux/arm64"]
-    cache-to = [ notequal("",BAKE_CACHENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/example_controller_python:${BAKE_CACHENAME}" : "" ]
-    cache-from = [ notequal("",BAKE_CACHENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/example_controller_python:${BAKE_CACHENAME}" : "" ]
+    cache-to = [ notequal("",BAKE_CACHENAME_TO) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/example_controller_python:${BAKE_CACHENAME_TO}" : "" ]
+    cache-from = [ notequal("",BAKE_CACHENAME_FROM) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/example_controller_python:${BAKE_CACHENAME_FROM}" : "" ]
 }
 
 /*
@@ -160,6 +172,6 @@ target "starling-sim-iris" {
         notequal("",BAKE_RELEASENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-sim-iris:${BAKE_RELEASENAME}": "",
         ]
     platforms = ["linux/amd64"]
-    cache-to = [ notequal("",BAKE_CACHENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-sim-iris:${BAKE_CACHENAME}" : "" ]
-    cache-from = [ notequal("",BAKE_CACHENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-sim-iris:${BAKE_CACHENAME}" : "" ]
+    cache-to = [ notequal("",BAKE_CACHENAME_TO) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-sim-iris:${BAKE_CACHENAME_TO}" : "" ]
+    cache-from = [ notequal("",BAKE_CACHENAME_FROM) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-sim-iris:${BAKE_CACHENAME_FROM}" : "" ]
 }

--- a/buildtools/docker-bake.hcl
+++ b/buildtools/docker-bake.hcl
@@ -10,20 +10,20 @@ variable "BAKE_RELEASENAME" {
     default = ""
 }
 
-variable "BAKE_CACHE_REGISTRY" {
-    default = "${BAKE_REGISTRY}"
-}
-
-variable "BAKE_CACHENAME" {
+variable "BAKE_CACHEFROM_REGISTRY" {
     default = ""
 }
 
-variable "BAKE_CACHENAME_FROM" {
-    default = "${BAKE_CACHENAME}"
+variable "BAKE_CACHETO_REGISTRY" {
+    default = ""
 }
 
-variable "BAKE_CACHENAME_TO" {
-    default = "${BAKE_CACHENAME}"
+variable "BAKE_CACHEFROM_NAME" {
+    default = ""
+}
+
+variable "BAKE_CACHETO_NAME" {
+    default = ""
 }
 
 /*
@@ -55,8 +55,8 @@ target "starling-ui" {
         notequal("",BAKE_RELEASENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-ui:${BAKE_RELEASENAME}": "",
         ]
     platforms = ["linux/amd64"]
-    cache-to = [ notequal("",BAKE_CACHENAME_TO) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-ui:${BAKE_CACHENAME_TO}" : "" ]
-    cache-from = [ notequal("",BAKE_CACHENAME_FROM) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-ui:${BAKE_CACHENAME_FROM}" : "" ]
+    cache-to = [ notequal("",BAKE_CACHETO_NAME) ? "${BAKE_CACHETO_REGISTRY}uobflightlabstarling/starling-ui:${BAKE_CACHETO_NAME}" : "" ]
+    cache-from = [ notequal("",BAKE_CACHEFROM_NAME) ? "${BAKE_CACHEFROM_REGISTRY}uobflightlabstarling/starling-ui:${BAKE_CACHEFROM_NAME}" : "" ]
 }
 
 target "starling-controller-base" {
@@ -66,8 +66,8 @@ target "starling-controller-base" {
         notequal("",BAKE_RELEASENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-controller-base:${BAKE_RELEASENAME}": "",
         ]
     platforms = ["linux/amd64", "linux/arm64"]
-    cache-to = [ notequal("",BAKE_CACHENAME_TO) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-controller-base:${BAKE_CACHENAME_TO}" : "" ]
-    cache-from = [ notequal("",BAKE_CACHENAME_FROM) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-controller-base:${BAKE_CACHENAME_FROM}" : "" ]
+    cache-to = [ notequal("",BAKE_CACHETO_NAME) ? "${BAKE_CACHETO_REGISTRY}uobflightlabstarling/starling-controller-base:${BAKE_CACHETO_NAME}" : "" ]
+    cache-from = [ notequal("",BAKE_CACHEFROM_NAME) ? "${BAKE_CACHEFROM_REGISTRY}uobflightlabstarling/starling-controller-base:${BAKE_CACHEFROM_NAME}" : "" ]
 }
 
 target "starling-mavros" {
@@ -77,8 +77,8 @@ target "starling-mavros" {
         notequal("",BAKE_RELEASENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-mavros:${BAKE_RELEASENAME}": "",
         ]
     platforms = ["linux/amd64", "linux/arm64"]
-    cache-to = [ notequal("",BAKE_CACHENAME_TO) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-mavros:${BAKE_CACHENAME_TO}" : "" ]
-    cache-from = [ notequal("",BAKE_CACHENAME_FROM) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-mavros:${BAKE_CACHENAME_FROM}" : "" ]
+    cache-to = [ notequal("",BAKE_CACHETO_NAME) ? "${BAKE_CACHETO_REGISTRY}uobflightlabstarling/starling-mavros:${BAKE_CACHETO_NAME}" : "" ]
+    cache-from = [ notequal("",BAKE_CACHEFROM_NAME) ? "${BAKE_CACHEFROM_REGISTRY}uobflightlabstarling/starling-mavros:${BAKE_CACHEFROM_NAME}" : "" ]
 }
 
 
@@ -99,8 +99,8 @@ target "starling-sim-base-core" {
         notequal("",BAKE_RELEASENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-sim-base-core:${BAKE_RELEASENAME}": "",
         ]
     platforms = ["linux/amd64"]
-    cache-to = [ notequal("",BAKE_CACHENAME_TO) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-sim-base-core:${BAKE_CACHENAME_TO}" : "" ]
-    cache-from = [ notequal("",BAKE_CACHENAME_FROM) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-sim-base-core:${BAKE_CACHENAME_FROM}" : "" ]
+    cache-to = [ notequal("",BAKE_CACHETO_NAME) ? "${BAKE_CACHETO_REGISTRY}uobflightlabstarling/starling-sim-base-core:${BAKE_CACHETO_NAME}" : "" ]
+    cache-from = [ notequal("",BAKE_CACHEFROM_NAME) ? "${BAKE_CACHEFROM_REGISTRY}uobflightlabstarling/starling-sim-base-core:${BAKE_CACHEFROM_NAME}" : "" ]
 }
 
 group "simulator-px4" {
@@ -122,8 +122,8 @@ target "starling-sim-base-px4" {
         notequal("",BAKE_RELEASENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-sim-base-px4:${BAKE_RELEASENAME}": "",
         ]
     platforms = ["linux/amd64"]
-    cache-to = [ notequal("",BAKE_CACHENAME_TO) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-sim-base-px4:${BAKE_CACHENAME_TO}" : "" ]
-    cache-from = [ notequal("",BAKE_CACHENAME_FROM) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-sim-base-px4:${BAKE_CACHENAME_FROM}" : "" ]
+    cache-to = [ notequal("",BAKE_CACHETO_NAME) ? "${BAKE_CACHETO_REGISTRY}uobflightlabstarling/starling-sim-base-px4:${BAKE_CACHETO_NAME}" : "" ]
+    cache-from = [ notequal("",BAKE_CACHEFROM_NAME) ? "${BAKE_CACHEFROM_REGISTRY}uobflightlabstarling/starling-sim-base-px4:${BAKE_CACHEFROM_NAME}" : "" ]
 }
 
 target "starling-sim-px4-sitl" {
@@ -134,8 +134,8 @@ target "starling-sim-px4-sitl" {
         notequal("",BAKE_RELEASENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-sim-px4-sitl:${BAKE_RELEASENAME}": "",
         ]
     platforms = ["linux/amd64"]
-    cache-to = [ notequal("",BAKE_CACHENAME_TO) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-sim-px4-sitl:${BAKE_CACHENAME_TO}" : "" ]
-    cache-from = [ notequal("",BAKE_CACHENAME_FROM) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-sim-px4-sitl:${BAKE_CACHENAME_FROM}" : "" ]
+    cache-to = [ notequal("",BAKE_CACHETO_NAME) ? "${BAKE_CACHETO_REGISTRY}uobflightlabstarling/starling-sim-px4-sitl:${BAKE_CACHETO_NAME}" : "" ]
+    cache-from = [ notequal("",BAKE_CACHEFROM_NAME) ? "${BAKE_CACHEFROM_REGISTRY}uobflightlabstarling/starling-sim-px4-sitl:${BAKE_CACHEFROM_NAME}" : "" ]
 }
 
 /*
@@ -153,8 +153,8 @@ target "example_python_controller" {
         notequal("",BAKE_RELEASENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/example_controller_python:${BAKE_RELEASENAME}": "",
         ]
     platforms = ["linux/amd64", "linux/arm64"]
-    cache-to = [ notequal("",BAKE_CACHENAME_TO) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/example_controller_python:${BAKE_CACHENAME_TO}" : "" ]
-    cache-from = [ notequal("",BAKE_CACHENAME_FROM) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/example_controller_python:${BAKE_CACHENAME_FROM}" : "" ]
+    cache-to = [ notequal("",BAKE_CACHETO_NAME) ? "${BAKE_CACHETO_REGISTRY}uobflightlabstarling/example_controller_python:${BAKE_CACHETO_NAME}" : "" ]
+    cache-from = [ notequal("",BAKE_CACHEFROM_NAME) ? "${BAKE_CACHEFROM_REGISTRY}uobflightlabstarling/example_controller_python:${BAKE_CACHEFROM_NAME}" : "" ]
 }
 
 /*
@@ -172,6 +172,6 @@ target "starling-sim-iris" {
         notequal("",BAKE_RELEASENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/starling-sim-iris:${BAKE_RELEASENAME}": "",
         ]
     platforms = ["linux/amd64"]
-    cache-to = [ notequal("",BAKE_CACHENAME_TO) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-sim-iris:${BAKE_CACHENAME_TO}" : "" ]
-    cache-from = [ notequal("",BAKE_CACHENAME_FROM) ? "${BAKE_CACHE_REGISTRY}uobflightlabstarling/starling-sim-iris:${BAKE_CACHENAME_FROM}" : "" ]
+    cache-to = [ notequal("",BAKE_CACHETO_NAME) ? "${BAKE_CACHETO_REGISTRY}uobflightlabstarling/starling-sim-iris:${BAKE_CACHETO_NAME}" : "" ]
+    cache-from = [ notequal("",BAKE_CACHEFROM_NAME) ? "${BAKE_CACHEFROM_REGISTRY}uobflightlabstarling/starling-sim-iris:${BAKE_CACHEFROM_NAME}" : "" ]
 }

--- a/buildtools/seed_caches.sh
+++ b/buildtools/seed_caches.sh
@@ -2,10 +2,8 @@
 
 # Seed the cache tag on DockerHub
 
-export BAKE_CACHENAME_TO=cache
-export BAKE_CACHE_REGISTRY=""
+export BAKE_CACHETO_NAME=cache
 
 ./build_local_multiplatform.sh
 
-unset BAKE_CACHENAME_TO
-unset BAKE_CACHE_REGISTRY
+unset BAKE_CACHETO_NAME

--- a/buildtools/seed_caches.sh
+++ b/buildtools/seed_caches.sh
@@ -2,8 +2,10 @@
 
 # Seed the cache tag on DockerHub
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
 export BAKE_CACHETO_NAME=cache
 
-./build_local_multiplatform.sh
+${SCRIPT_DIR}/build_local_multiplatform.sh
 
 unset BAKE_CACHETO_NAME

--- a/buildtools/seed_caches.sh
+++ b/buildtools/seed_caches.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Seed the cache tag on DockerHub
+
+export BAKE_CACHENAME_TO=cache
+export BAKE_CACHE_REGISTRY=""
+
+./build_local_multiplatform.sh
+
+unset BAKE_CACHENAME_TO
+unset BAKE_CACHE_REGISTRY

--- a/docs/details/build_system.md
+++ b/docs/details/build_system.md
@@ -40,6 +40,13 @@ both the tag specified by `BAKE_VERSION` (or `latest` if that is not set) and th
 If set, `BAKE_CACHENAME` will tell `bake` to use a registry based cache to speed up builds. Both of these options are
 primarily to ease the use of GitHub actions.
 
+Finally, there are some further options to control caching further. `BAKE_CACHE_REGISTRY` overrides the destination
+registry for the cache images. By default, it will have the same value as `BAKE_REGISTRY`. This exists to allow local
+builds to be cached from online sources and pushed to a local registry or to allow local builds to be used to populate
+the online caches. The other options are `BAKE_CACHENAME_FROM` and `BAKE_CACHENAME_TO`, which by default take their
+value from `BAKE_CACHENAME`. When not set, no caches will be used. These exist to allow one-directional caching, _e.g._
+to refresh the online caches.
+
 ## The GitHub Actions Workflows
 
 When a tag of the form `vX.Y.Z` is pushed to the repo, a workflow will be started. This workflow builds all the images

--- a/docs/details/build_system.md
+++ b/docs/details/build_system.md
@@ -34,18 +34,16 @@ using Docker Hub. Once built, the images can be pulled from the local registry u
 Override by setting `BAKE_REGISTRY` in the environment before calling `bake`.
 
 The `bake.hcl` script takes values from the environment to be passed on to the Dockerfiles. Two of these are the
-`BAKE_VERSION` and `BAKE_REGISTRY` arguments outlined above. Two other values can be supplied to the `bake.hcl` script:
-`BAKE_RELEASENAME` and `BAKE_CACHENAME`. `BAKE_RELEASENAME` defaults to blank. If set, all images will be tagged with
-both the tag specified by `BAKE_VERSION` (or `latest` if that is not set) and that specified by `BAKE_RELEASENAME`.
-If set, `BAKE_CACHENAME` will tell `bake` to use a registry based cache to speed up builds. Both of these options are
-primarily to ease the use of GitHub actions.
+`BAKE_VERSION` and `BAKE_REGISTRY` arguments outlined above. `BAKE_RELEASENAME` can also be supplied to the `bake.hcl`
+script. `BAKE_RELEASENAME` defaults to blank. If it is set, all images will be tagged with both the tag specified by
+`BAKE_VERSION` (or `latest` if that is not set) and that specified by `BAKE_RELEASENAME`.
 
-Finally, there are some further options to control caching further. `BAKE_CACHE_REGISTRY` overrides the destination
-registry for the cache images. By default, it will have the same value as `BAKE_REGISTRY`. This exists to allow local
-builds to be cached from online sources and pushed to a local registry or to allow local builds to be used to populate
-the online caches. The other options are `BAKE_CACHENAME_FROM` and `BAKE_CACHENAME_TO`, which by default take their
-value from `BAKE_CACHENAME`. When not set, no caches will be used. These exist to allow one-directional caching, _e.g._
-to refresh the online caches.
+Finally, there are some further options to control caching. The main options are `BAKE_CACHETO_NAME` and
+`BAKE_CACHEFROM_NAME`, which by default are blank. These exists to allow local builds to be cached from online sources
+and pushed to a local registry or to allow local builds to be used to populate the online caches. When they are blank,
+no caches will be used. This allows for one-directional caching, _e.g._ refreshing the online caches from local builds.
+Two further caching options are available: `BAKE_CACHETO_REGISTRY` and `BAKE_CACHEFROM_REGISTRY`. These control the
+destination and source registries for the cache images. By default, they will be blank, equivalent to using Docker Hub. 
 
 ## The GitHub Actions Workflows
 

--- a/docs/details/build_system.md
+++ b/docs/details/build_system.md
@@ -19,7 +19,14 @@ to the images and passed as the `VERSION` build argument to dockerfiles that dep
 Multiplatform support is more complicated. The local docker image store cannot handle multi-platform images so
 `buildx`'s default `docker` driver cannot be used. `build_local_multiplatform.sh` deals with this by spawning a new
 builder using the `docker-container` driver alongside a local container registry that the builder interacts with. This
-significantly complicates things. **At present there is a problem with the ARM builds**
+significantly complicates things.
+
+To setup your local machine to do the multiplatform builds, you need to install the required emulators for the `arm64`
+builds. Luckily someone has already done the hard work. All that should be required is:
+
+```
+docker run --privileged --rm tonistiigi/binfmt --install arm64
+```
 
 Similar to the `VERSION` argument outlined above, the use of a local registry requires a `REGISTRY` build argument be
 used in the Dockerfiles. Again this is provided by the `bake.hcl` script. It defaults to blank, which is equivalent to


### PR DESCRIPTION
Updates the build scripts to allow more flexibility in caching. Especially useful after problems upstream _cough_ ROS2 _cough_

Adds a `seed_caches` script which build locally and uploads to Docker Hub cache.

Also adds some extra hints on multiplatform builds to the documentation. This effectively fixes #53 not that there was actually anything broken in the repo.