### PR TITLE
Simple offboard deployment and added namespacing to mavros bridge

### DIFF
--- a/deployment/k8.px4-sitl-simple-offboard.amd64.yaml
+++ b/deployment/k8.px4-sitl-simple-offboard.amd64.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: starling-px4-sitl
+  labels:
+    app: starling
+    platform: sitl
+spec:
+  serviceName: starling-px4-sitl-srv
+  selector:
+    matchLabels:
+      app: starling
+      firmware: px4
+      platform: sitl
+  template:
+    metadata:
+      labels:
+        app: starling
+        firmware: px4
+        platform: sitl
+    spec:
+      hostNetwork: true
+      terminationGracePeriodSeconds: 10
+      shareProcessNamespace: true
+      initContainers:
+      - name: gazebo-spawn-iris
+        image: uobflightlabstarling/starling-sim-iris:latest
+        imagePullPolicy: IfNotPresent
+        args: [ "./spawn_iris.sh" ]
+        env:
+        - name: PX4_INSTANCE
+          value: "ordinal"
+        - name: PX4_INSTANCE_BASE
+          value: "200"
+        - name: IGNORE_FAILURE
+          value: "true"
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+      containers:
+      - name: starling-px4-sitl
+        image: uobflightlabstarling/starling-sim-px4-sitl:latest
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: PX4_SIM_HOST
+          value: "localhost"
+        - name: PX4_INSTANCE
+          value: "ordinal"
+        - name: PX4_INSTANCE_BASE
+          value: "200"
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+      - name: starling-mavros
+        image: uobflightlabstarling/starling-mavros:latest
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: VEHICLE_NAMESPACE # Optional but unique
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name # Pod name
+        - name: MAVROS_TGT_FIRMWARE
+          value: "px4"
+        - name: MAVROS_TGT_SYSTEM
+          value: "auto"
+        - name: PX4_INSTANCE_BASE
+          value: "200"
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+      - name: starling-simple-offboard
+        image: uobflightlabstarling/starling-simple-offboard:latest
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: VEHICLE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name # Pod name
+
+      nodeSelector:
+        kubernetes.io/arch: "amd64"

--- a/deployment/k8.starling-ui-dashly.yaml
+++ b/deployment/k8.starling-ui-dashly.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starling-ui
+spec:
+  selector:
+    matchLabels:
+      app: starling-ui
+  template:
+    metadata:
+      labels:
+        app: starling-ui
+    spec:
+      hostNetwork: true
+      shareProcessNamespace: true
+      containers:
+      - name: starling-ui
+        image: mickeyli789/starling-ui-dashly:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 3000
+        - containerPort: 9090

--- a/scripts/start_single_px4sitl_gazebo_simple_offboard.sh
+++ b/scripts/start_single_px4sitl_gazebo_simple_offboard.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+set -e
+
+echo "----- Start: $0 -----"
+
+ARGS="$@"
+
+# Parse arguments
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+    case $key in
+        -h|--help)
+            HELP=1
+            shift # past argument
+            ;;
+        -ow|--open)
+            OPENWEBPAGE=1
+            shift # past argument
+            ;;
+        -d|--delete)
+            DELETE=1
+            shift
+            ;;
+        -sk|--skip-base-check)
+            SKIP_BASE=1
+            shift
+            ;;
+        -r|--restart)
+            DELETE=1
+            RESTART=1
+            shift
+            ;;
+        *)    # unknown option
+            POSITIONAL+=("$1") # save it in an array for later
+            shift # past argument
+            ;;
+    esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
+if [[ $HELP ]]
+then
+    echo "Script starts both gazebo and a single px4 instance"
+    echo "If the base is not running, this script will start the base"
+    echo "If already started nothing will happen"
+    echo "Usage: ./start_single_px4sitl_gazebo.sh [-h | --help] [-ow | --open]"
+    echo "--open will automatically open the associated web pages"
+    exit -1
+fi
+
+SCRIPTSDIR="${BASH_SOURCE%/*}"
+SYSTEMDIR="$SCRIPTSDIR/../system"
+DEPLOYMENTDIR="$SCRIPTSDIR/../deployment"
+
+
+if [[ $DELETE ]]; then
+    echo "Deleting Gazebo-iris"
+    kubectl delete -f $DEPLOYMENTDIR/k8.gazebo-iris.amd64.yaml
+    echo "Deleting px4-sitl with mavros and simple offboard controller"
+    kubectl delete -f $DEPLOYMENTDIR/k8.px4-sitl-simple-offboard.amd64.yaml
+fi
+
+if [[ $RESTART ]]; then
+    echo "Restarting, sleeping 30";
+    sleep 30;
+fi
+
+if [[ ! $DELETE || $RESTART ]]; then
+
+    if [[ ! $SKIP_BASE ]]; then
+        # Start/ Check starling base
+        echo "Starting Starling Base, args: $ARGS"
+        ./$SCRIPTSDIR/start_starling_base.sh $ARGS
+    else
+        echo "Skipping Base Check"
+    fi
+
+    echo "Deploying Starling Modules (this may take a while)"
+    echo "Deploying Gazebo-iris to localhost:8080 and wait for start"
+    kubectl apply -f $DEPLOYMENTDIR/k8.gazebo-iris.amd64.yaml
+
+    echo "Waiting 5s for Gazebo to start to ensure proper connection"
+    sleep 5s
+
+    echo "Deploying px4-sitl with mavros and simple offboard controller"
+    kubectl apply -f $DEPLOYMENTDIR/k8.px4-sitl-simple-offboard.amd64.yaml
+
+    if [[ $OPENWEBPAGE ]]
+    then
+        echo "Opening gazebo to http://localhost:8080"
+        xdg-open http://localhost:8080
+    fi
+fi
+
+echo "----- End: $0 -----"

--- a/scripts/start_starling_base.sh
+++ b/scripts/start_starling_base.sh
@@ -43,17 +43,18 @@ fi
 
 SCRIPTSDIR="${BASH_SOURCE%/*}"
 SYSTEMDIR="$SCRIPTSDIR/../system"
+DEPLOYMENTDIR="$SCRIPTSDIR/../deployment"
 
 # Start dashboard
 ./$SCRIPTSDIR/start_dashboard.sh
 
 # Start starling UI
-kubectl apply -f "$SYSTEMDIR/ui/kubernetes.yaml"
+kubectl apply -f "$DEPLOYMENTDIR/k8.starling-ui-dashly.yaml"
 
 if [[ $OPENWEBPAGE ]]
 then
-    echo "Opening Starling UI to http://localhost:3000/html/main.html"
-    xdg-open http://localhost:3000/html/main.html
+    echo "Opening Starling UI to http://localhost:3000"
+    xdg-open http://localhost:3000
 
     echo "Opening Dashboard to https://localhost:31771"
     xdg-open https://localhost:31771

--- a/system/mavros/mavros_bridge.launch.xml
+++ b/system/mavros/mavros_bridge.launch.xml
@@ -6,7 +6,7 @@
     <arg name="gcs_url" default="$(env MAVROS_GCS_URL)" />
     <arg name="target_system" default="$(env MAVROS_TGT_SYSTEM)" />
     <arg name="system_id" default="$(env MAVROS_TGT_SYSTEM)" />
-    
+
     <!-- Launch the ROS1 stack -->
     <executable cmd="/ros_ws/scripts/run_ros1.sh roslaunch /ros_ws/launch/mavros.launch
             vehicle_namespace:=$(var vehicle_namespace)
@@ -18,7 +18,11 @@
         output="screen"
     />
 
-    <!-- Launch the bridge -->
-    <node pkg="ros1_bridge" exec="dynamic_bridge" args="--bridge-all-1to2-topics" />
+    <!-- Launch the bridge in the correct namespace to avoid collisions-->
+    <group>
+        <push-ros-namespace namespace="$(var vehicle_namespace)"/>
+        <node pkg="ros1_bridge" exec="dynamic_bridge" args="--bridge-all-1to2-topics" />
+    </group>
+
 
 </launch>


### PR DESCRIPTION
This PR primarily ensures that the mavros bridge runs in the Vehicle Namespace to avoid node name clashes with multiple simulated drones (unsure as to why this was not a problem earlier) 

This PR also adds a simulator deployment which includes the simple_offboard 