### PR TITLE
Vicon build recursive with submoduels

### DIFF
--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -260,6 +260,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
 
       - name: Get tag name
         id: tag_name


### PR DESCRIPTION
This PR changes the vicon build script to pull recursively to ensure the vicon_udp submodule is also checked out... otherwise nothing gets built